### PR TITLE
ナビバーの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,11 @@
   padding: 1rem;
 }
 
+/* body */
+body {
+  padding-top: 69px;
+}
+
 /* max-width */
 
 .mw-sm {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,9 +1,39 @@
-<% if user_signed_in? %>
-  <%# ログイン時%>
-  <%= link_to "アカウント編集", edit_user_registration_path %>
-  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-<% else %>
-  <%# 非ログイン時%>
-  <%= link_to "新規登録", new_user_registration_path %>
-  <%= link_to "ログイン", new_user_session_path %>
-<% end %>
+<nav class="navbar navbar-expand-md navbar-dark bg-primary fixed-top">
+  <a class="navbar-brand" href=http://localhost:3000>
+    <%= image_tag ("yanbaru_expert_logo.png") %>
+  </a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+    <ul class="navbar-nav">
+      <li class="navbar-item dropdown">
+        <a class="nav-link dropdown-toggle text-white" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Ruby
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <%= link_to "Ruby/Railsテキスト教材", texts_path, class: "dropdown-item" %>
+          <%= link_to "Ruby/Rails動画教材", movies_path, class: "dropdown-item" %>
+        </div>
+      </li>
+      <li class="navbar-item dropdown">
+        <a class="nav-link dropdown-toggle text-white" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          PHP
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <%= link_to "PHPテキスト教材", texts_path(genre: "php"), class: "dropdown-item" %>
+          <%= link_to "PHP動画教材", movies_path(genre: "php"), class: "dropdown-item" %>
+        </div>
+      </li>
+      <% if user_signed_in? %>
+        <%# ログイン時%>
+        <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link text-white" %>
+        <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "nav-item nav-link text-white" %>
+      <% else %>
+        <%# 非ログイン時%>
+        <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link text-white" %>
+        <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link text-white" %>
+      <% end %>
+    </ul>
+  </div>
+</nav>


### PR DESCRIPTION
close #11 

## 実装内容

- BootstrapのNavbarを使用し、ナビバーを作成
  - `app/views/layouts/_header.html.erb`を編集
  - `fixed-top`で上部に固定
  - ロゴは`app/assets/images/yanbaru_expert_logo.png`を利用
  - ドロップダウンで`Ruby`,`PHP`のリンクを追加
  - PHPテキスト教材のパスは `texts_path(genre: "php")`, 動画教材は `movies_path(genre: "php")` とする
  - `md`サイズ未満でハンバーガーメニューに切り替わるようにする
  - コンテンツがヘッダーで隠れないよう`body`タグに`padding-top`を設定

## 確認内容
- ドロップダウン、ハンバーガーメニューが問題なく動作しているか確認
- 各リンクのURLが正常であるかを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行
