### PR TITLE
動画教材ページのジャンル分け

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,6 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.genre
+    # binding.pry
+    @movies = Movie.select_by_genre(params[:genre])
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,9 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = if params[:genre] == "php"
+                Movie.where(genre: "php")
+              else
+                Movie.where(genre: Movie::RAILS_GENRE_LIST)
+              end
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,11 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    if params[:genre] == "php"
-      @movies = Movie.php
-      @genre = "PHP"
-    else
-      @movies = Movie.rails_genre_list
-      @genre = "Ruby/Rails"
-    end
+    @movies = Movie.genre
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,8 +1,9 @@
 class MoviesController < ApplicationController
   def index
     @movies = if params[:genre] == "php"
-                Movie.where(genre: "php")
+                Movie.where(genre: Movie::PHP)
               else
+                Movie.RAILS_GENRE_LIST
                 Movie.where(genre: Movie::RAILS_GENRE_LIST)
               end
   end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,10 +1,11 @@
 class MoviesController < ApplicationController
   def index
-    @movies = if params[:genre] == "php"
-                Movie.where(genre: Movie::PHP)
-              else
-                Movie.RAILS_GENRE_LIST
-                Movie.where(genre: Movie::RAILS_GENRE_LIST)
-              end
+    if params[:genre] == "php"
+      @movies = Movie.PHP
+      @title = "PHP 動画"
+    else
+      @movies = Movie.RAILS_GENRE_LIST
+      @title = "Ruby/Rails 動画"
+    end
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    # binding.pry
     @movies = Movie.select_by_genre(params[:genre])
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,10 +1,10 @@
 class MoviesController < ApplicationController
   def index
     if params[:genre] == "php"
-      @movies = Movie.PHP
+      @movies = Movie.php
       @genre = "PHP"
     else
-      @movies = Movie.RAILS_GENRE_LIST
+      @movies = Movie.rails_genre_list
       @genre = "Ruby/Rails"
     end
   end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -2,10 +2,10 @@ class MoviesController < ApplicationController
   def index
     if params[:genre] == "php"
       @movies = Movie.PHP
-      @title = "PHP 動画"
+      @genre = "PHP"
     else
       @movies = Movie.RAILS_GENRE_LIST
-      @title = "Ruby/Rails 動画"
+      @genre = "Ruby/Rails"
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,8 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def title(genre)
+    "#{genre} 動画"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,11 @@ module ApplicationHelper
     end
   end
 
-  def title(genre)
-    "#{genre} 動画"
+  def title
+    if params[:genre] == "php"
+      "PHP動画"
+    else
+      "Ruby/Rails動画"
+    end
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -18,6 +18,10 @@ class Movie < ApplicationRecord
     params[:genre] == "php"
   end
 
+  def self.RAILS_GENRE_LIST
+    where(genre: "basic", "git", "ruby", "rails")
+  end
+
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
   PHP = %w[php].freeze
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -14,11 +14,13 @@ class Movie < ApplicationRecord
     php: 5
   }
 
-  def self.php
-    where(genre: ["php"])
-  end
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
-  def self.rails_genre_list
-    where(genre: ["basic", "git", "ruby", "rails"])
+  def self.genre
+    if :genre == "php"
+      where(genre: "php")
+    else
+      where(genre: RAILS_GENRE_LIST)
+    end
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -14,11 +14,11 @@ class Movie < ApplicationRecord
     php: 5
   }
 
-  def self.PHP
+  def self.php
     where(genre: ["php"])
   end
 
-  def self.RAILS_GENRE_LIST
+  def self.rails_genre_list
     where(genre: ["basic", "git", "ruby", "rails"])
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -14,14 +14,11 @@ class Movie < ApplicationRecord
     php: 5
   }
 
-  def php?
-    params[:genre] == "php"
+  def self.PHP
+    where(genre: ["php"])
   end
 
   def self.RAILS_GENRE_LIST
-    where(genre: "basic", "git", "ruby", "rails")
+    where(genre: ["basic", "git", "ruby", "rails"])
   end
-
-  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
-  PHP = %w[php].freeze
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -14,5 +14,10 @@ class Movie < ApplicationRecord
     php: 5
   }
 
+  def php?
+    params[:genre] == "php"
+  end
+
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP = %w[php].freeze
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -16,8 +16,8 @@ class Movie < ApplicationRecord
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
-  def self.select_by_genre(_genre)
-    if params[:genre] == "php"
+  def self.select_by_genre(genre)
+    if genre == "php"
       where(genre: "php")
     else
       where(genre: RAILS_GENRE_LIST)

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -16,8 +16,8 @@ class Movie < ApplicationRecord
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
-  def self.genre
-    if :genre == "php"
+  def self.select_by_genre(_genre)
+    if params[:genre] == "php"
       where(genre: "php")
     else
       where(genre: RAILS_GENRE_LIST)

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= @title %></h1>
+<h1><%= title(@genre) %></h1>
 <div class="row">
   <div class="card-deck">
     <%= render partial: "movie", collection: @movies %>    

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,4 @@
-<h1><%= title(@genre) %></h1>
+<h1><%= title %></h1>
 <div class="row">
   <div class="card-deck">
     <%= render partial: "movie", collection: @movies %>    

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Ruby/Rails 動画</h1>
+<h1><%= @title %></h1>
 <div class="row">
   <div class="card-deck">
     <%= render partial: "movie", collection: @movies %>    


### PR DESCRIPTION
close #18 

## 実装内容

- `movies_controller.rb`にgenreでの場合分けするように実装
- `movie.rb`にphpとphp以外のgenreを定義
- `application_helper.rb`に動画タイトルを定義
- `movies/index.html.erb`のタイトルに`application_helper.rb`で定義したメソッドに変更

## 確認内容
- 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- クエリパラメータ ?genre=php を php 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行