### PR TITLE
テキスト教材の読破済み機能

### DIFF
--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,11 @@
+class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,11 @@
 class ReadProgressesController < ApplicationController
   def create
-    current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.create!(text_id: @text.id)
   end
 
   def destroy
-    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.find_by(text_id: @text.id).destroy!
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.includes(:user, :read_progresses).where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.includes(:users, :read_progresses).where(genre: Text::RAILS_GENRE_LIST)
   end
 
   def show; end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.includes(:user, :read_progresses).where(genre: Text::RAILS_GENRE_LIST)
   end
 
   def show; end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,9 @@
+class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+
+  validates :user_id, uniqueness: {
+    scope: :text_id,
+    message: :duplicated
+  }
+end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,6 +1,6 @@
 class Text < ApplicationRecord
-  belongs_to :user
   has_many :read_progresses, dependent: :destroy
+  has_many :user, dependent: :destroy, through: :read_progresses
 
   with_options presence: true do
     validates :genre

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -20,6 +20,6 @@ class Text < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
   def read_progressed_by?(user)
-    read_progresses.exists?(user_id: user.id)
+    read_progresses.any? { |read_progress| read_progress.user_id == user.id }
   end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,5 @@
 class Text < ApplicationRecord
-  has_many :readprogress, dependant: :destroy
+  has_many :readprogresses, dependent: :destroy
 
   with_options presence: true do
     validates :genre

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,6 @@
 class Text < ApplicationRecord
+  has_many :readprogress, dependant: :destroy
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -17,4 +17,8 @@ class Text < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  def read_progressed_by?(user)
+    read_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,5 +1,5 @@
 class Text < ApplicationRecord
-  has_many :readprogresses, dependent: :destroy
+  has_many :read_progresses, dependent: :destroy
 
   with_options presence: true do
     validates :genre

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,6 +1,6 @@
 class Text < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
-  has_many :user, dependent: :destroy, through: :read_progresses
+  has_many :user, through: :read_progresses
 
   with_options presence: true do
     validates :genre

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,5 @@
 class Text < ApplicationRecord
+  belongs_to :user
   has_many :read_progresses, dependent: :destroy
 
   with_options presence: true do

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,6 +1,6 @@
 class Text < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
-  has_many :user, through: :read_progresses
+  has_many :users, through: :read_progresses
 
   with_options presence: true do
     validates :genre

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :readprogresses, dependent: :destroy
+  has_many :read_progresses, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-  has_many :texts, dependent: :destroy
   has_many :read_progresses, dependent: :destroy
+  has_many :texts, dependent: :destroy, through: :read_progresses
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_many :read_progresses, dependent: :destroy
-  has_many :texts, dependent: :destroy, through: :read_progresses
+  has_many :texts, through: :read_progresses
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :readprogress, dependant: :destroy
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :texts, dependent: :destroy
   has_many :read_progresses, dependent: :destroy
 
   # Include default devise modules. Others available are:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :readprogress, dependant: :destroy
+  has_many :readprogresses, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/read_progress", text: @text) %>'

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/unread_progress", text: @text) %>'

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みを解除する", text_read_progresses_path(text), class: "btn btn-primary text-list__button", method: :delete %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), class: "btn btn-primary text-list__button", method: :delete, remote: true %>

--- a/app/views/texts/_read_progress.html.erb
+++ b/app/views/texts/_read_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みを解除する", text_read_progresses_path(text), class: "btn btn-primary text-list__button", method: :delete %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -2,7 +2,7 @@
   <div class="card text-item">
     <%= image_tag("default_image.jpg")  %>
     <div class="card-body">
-      <p>
+      <p id="text-<%= text.id %>">
         <% if text.read_progressed_by?(current_user) %>
           <%= render "read_progress", text: text %>
         <% else %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -2,6 +2,11 @@
   <div class="card text-item">
     <%= image_tag("default_image.jpg")  %>
     <div class="card-body">
+      <% if text.read_progressed_by?(current_user) %>
+        済み
+      <% else %>
+        済みにする
+      <% end %>
       <a href="#" class="btn btn-secondary text-list__button">読破済みにする</a>
       <p class="text-list__title"><%= text.title %></p>
       <p>【<%= text.genre %>】</p>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -2,12 +2,13 @@
   <div class="card text-item">
     <%= image_tag("default_image.jpg")  %>
     <div class="card-body">
-      <% if text.read_progressed_by?(current_user) %>
-        済み
-      <% else %>
-        済みにする
-      <% end %>
-      <a href="#" class="btn btn-secondary text-list__button">読破済みにする</a>
+      <p>
+        <% if text.read_progressed_by?(current_user) %>
+          <%= render "read_progress", text: text %>
+        <% else %>
+          <%= render "unread_progress", text: text %>
+        <% end %>
+      </p>
       <p class="text-list__title"><%= text.title %></p>
       <p>【<%= text.genre %>】</p>
     </div>

--- a/app/views/texts/_unread_progress.html.erb
+++ b/app/views/texts/_unread_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary text-list__button", method: :post %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary text-list__button", method: :post, remote: true %>

--- a/app/views/texts/_unread_progress.html.erb
+++ b/app/views/texts/_unread_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みにする", text_read_progresses_path(text), class: "btn btn-secondary text-list__button", method: :post %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,10 +25,10 @@ ja:
       read_progress:
         user: ユーザー
         user_id: ユーザー
-        text: テキスト
+        text: テキスト教材
     errors:
       models:
         read_progress:
           attributes:
             user_id:
-              duplicated: は同じテキストに複数回の読破済みはできません
+              duplicated: は同じテキスト教材に2回以上読破済みはできません

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
     models:
       text: テキスト教材
       movie: 動画教材
+      read_progress: 読破済み
     attributes:
       text:
         genre: ジャンル
@@ -21,3 +22,13 @@ ja:
         genre: ジャンル
         title: タイトル
         url: URL
+      read_progress:
+        user: ユーザー
+        user_id: ユーザー
+        text: テキスト
+    errors:
+      models:
+        read_progress:
+          attributes:
+            user_id:
+              duplicated: は同じテキストに複数回の読破済みはできません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,13 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root "texts#index"
-  resources :texts, only: [:index, :show]
+
+  resources :texts do
+    resource :read_progresses, only: [:create, :destroy]
+  end
+
   resources :movies, only: [:index]
+
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end

--- a/db/migrate/20221030004506_create_read_progresses.rb
+++ b/db/migrate/20221030004506_create_read_progresses.rb
@@ -1,0 +1,12 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :read_progresses, [:user_id, :text_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_21_002208) do
+ActiveRecord::Schema.define(version: 2022_10_30_004506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2022_10_21_002208) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -66,4 +76,6 @@ ActiveRecord::Schema.define(version: 2022_10_21_002208) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
close #22 

## 実装内容

- ReadProgress モデルを作成（読破済み機能に使用する）
  - 外部キー設定あり
  - 一意性制約あり
  - UserモデルとTextモデルとの関連付け
  - 日本語訳の追加
- Textモデルにuserが読破済みにしているか判定するメソッドを定義
  - `_text.html.erb`で条件分岐
- ルーティングの設定変更(read_progressをtextsにネスト)
- read_progressコントローラにcreateとdestroyメソッドを定義
- `_read_progress.html.erb`と`_read_progress.html.erb`を作成し、レンダリング
- N＋1問題の対応
- 読破済み機能を非同期に

## 確認内容
- テキスト教材の読破済みボタンが正しく動作すること
- ReadProgressモデルに正しくデータが投入されていること
- コンソールでUserは同じテキスト教材を2回以上読破済みにできないこと
- ユーザーやテキスト教材なしで読破済みにできないこと

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行