### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.includes(:users, :read_progresses).where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.select_by_genre(params[:genre]).includes(:users, :read_progresses)
   end
 
   def show; end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,12 @@ module ApplicationHelper
       "Ruby/Rails動画"
     end
   end
+
+  def text_title
+    if params[:genre] == "php"
+      "PHP テキスト教材"
+    else
+      "Ruby/Rails テキスト教材"
+    end
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -19,6 +19,14 @@ class Text < ApplicationRecord
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
+  def self.select_by_genre(genre)
+    if genre == "php"
+      Text.where(genre: "php")
+    else
+      Text.where(genre: RAILS_GENRE_LIST)
+    end
+  end
+
   def read_progressed_by?(user)
     read_progresses.any? { |read_progress| read_progress.user_id == user.id }
   end

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <h1>Ruby/Rails テキスト教材</h1>
+  <h1><%= text_title %></h1>
 </div>
 <div class="container">
   <div class="row">


### PR DESCRIPTION
close #20 

## 実装内容

- PHPテキスト教材ページでPHPテキスト教材のみが表示されるように修正
  - PHPテキスト教材ページのクエリパラメータ`?genre=php`を利用し、モデルにクラスメソッドを作成
  - コントローラ側で作成したメソッドを使用した記述に変更。
- テキスト教材ページのタイトルをRuby/Railsの場合は、Ruby/Rails テキスト教材、PHPの場合はPHP テキスト教材と表示されるように修正
  - `application_helper.rb`にtext_titleメソッドを作成


## 確認内容
- ナビバーからPHPテキスト教材にアクセスし、PHPテキスト教材のみが表示されているか確認
- ナビバーからRuby/Railsテキスト教材にアクセスし、PHPテキスト教材が表示されていないか確認
- PHPテキスト教材ページでクエリパラメータをphp以外を選択した場合、Ruby/Railsテキスト教材が表示されるか確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行
