### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,11 +15,11 @@ gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 gem "rails", "~> 6.1.1"
 gem "rails-i18n", "~> 6.0"
+gem "redcarpet"
+gem "rouge"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem "redcarpet"
-gem "rouge"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem "rails-i18n", "~> 6.0"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
+gem "redcarpet"
+gem "rouge"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,11 +221,13 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     regexp_parser (2.5.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    rouge (4.0.0)
     rubocop (1.32.0)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -317,6 +319,8 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  redcarpet
+  rouge
   rubocop-performance
   rubocop-rails
   sass-rails (>= 6)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,3 +49,7 @@ body {
 .pagination {
   justify-content: center;
 }
+
+a:hover {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,6 +54,6 @@ a:hover {
   text-decoration: none;
 }
 
-img {
+.text-item img {
   width: 100%;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,3 +53,7 @@ body {
 a:hover {
   text-decoration: none;
 }
+
+img {
+  width: 100%;
+}

--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -1,0 +1,46 @@
+@import "bootstrap/scss/bootstrap";
+
+.markdown {
+  table {
+    @extend .table;
+    display: block;
+    overflow-x: scroll;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    border: initial;
+
+    thead {
+      background-color: #EEFFFF;
+    }
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    text-align: left;
+  }
+
+  pre {
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
+    background-color: #f6ffff;
+    padding: 0.5rem;
+    margin: 1rem 0;
+    border: 2px dashed #d6dddd;
+
+    code {
+      table.rouge-table {
+        margin: 0;
+
+        td.rouge-code {
+          padding: 0;
+          vertical-align: top;
+
+          pre {
+            padding: 5px 10px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -19,6 +19,11 @@
     text-align: left;
   }
 
+     h2 {
+       padding-top: 20px;
+       padding-bottom: 10px;
+     }
+
   pre {
     overflow: auto;
     word-wrap: normal;

--- a/app/assets/stylesheets/rouge.scss.erb
+++ b/app/assets/stylesheets/rouge.scss.erb
@@ -1,0 +1,1 @@
+<%= Rouge::Themes::Github.render(scope: '.highlight') %>

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,5 +3,7 @@ class TextsController < ApplicationController
     @texts = Text.includes(:users, :read_progresses).where(genre: Text::RAILS_GENRE_LIST)
   end
 
-  def show; end
+  def show
+    @text = Text.find(params[:id])
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,30 @@
+module MarkdownHelper
+  def markdown(text)
+    renderer = Redcarpet::Render::HTML.new(render_options)
+    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
+  end
+
+  private
+
+  def render_options
+    {
+      filter_html: false, # htmlを無効化
+      hard_wrap: true, # 改行を br 要素に変換
+      link_attributes: { target: "_blank", rel: "noopener" } # リンクの設定
+    }
+  end
+
+  def extensions
+    {
+      autolink: true, # http https ftpで始まる文字列を自動リンク
+      fenced_code_blocks: true, # コードブロックを解析
+      no_intra_emphasis: true, # 単語内の強調を解析しない
+      tables: true, # 	テーブルを解析
+      space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
+      hard_wrap: true, # 改行を br 要素に変換
+      xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
+      lax_html_blocks: true # 複数行のコードの前後に空行が不要
+      # strikethrough: true, # 取り消し線(~)を解析する
+    }
+  end
+end

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,16 +1,18 @@
-<div class="col-12 col-md-6 col-lg-4 text-item__container">
-  <div class="card text-item">
-    <%= image_tag("default_image.jpg")  %>
-    <div class="card-body">
-      <p id="text-<%= text.id %>">
-        <% if text.read_progressed_by?(current_user) %>
-          <%= render "read_progress", text: text %>
-        <% else %>
-          <%= render "unread_progress", text: text %>
-        <% end %>
-      </p>
-      <p class="text-list__title"><%= text.title %></p>
-      <p>【<%= text.genre %>】</p>
+    <%= link_to text_path(text) do %>
+  <div class="col-12 col-md-6 col-lg-4 text-item__container">
+    <div class="card text-item">
+      <%= image_tag("default_image.jpg")  %>
+      <div class="card-body">
+        <p id="text-<%= text.id %>">
+          <% if text.read_progressed_by?(current_user) %>
+            <%= render "read_progress", text: text %>
+          <% else %>
+            <%= render "unread_progress", text: text %>
+          <% end %>
+        </p>
+        <p class="text-list__title"><%= text.title %></p>
+        <p>【<%= text.genre %>】</p>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,7 @@
+<%
+  str = @text.content
+%>
+<div class="markdown">
+  <h2 class="text-center"><%= @text.title %></h2>
+  <%= markdown(str) %>
+</div>


### PR DESCRIPTION
## 実装内容

「タスク #13」完了後に行って下さい

- aタグの下線が入らないように `app/assets/stylesheets/application.scss` に次を追加

```css
/* 全体 */

a:hover {
  text-decoration: none;
}
```

- 一覧ページから詳細ページに移動できるようにする
  - `link_to` のブロックを利用するのがポイント

- マークダウン形式を変換する `redcarpet`, シンタックスハイライトを適用する `rouge` をインストール
  - `coderay` は使用していません

```rb
gem "redcarpet"
gem "rouge"
```

- `app/helpers/markdown_helper.rb` を作成し，次を設定

```rb
module MarkdownHelper
  def markdown(text)
    renderer = Redcarpet::Render::HTML.new(render_options)
    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
  end

  private

  def render_options
    {
      filter_html: false, # htmlを無効化
      hard_wrap: true, # 改行を br 要素に変換
      link_attributes: { target: "_blank", rel: "noopener" } # リンクの設定
    }
  end

  def extensions
    {
      autolink: true, # http https ftpで始まる文字列を自動リンク
      fenced_code_blocks: true, # コードブロックを解析
      no_intra_emphasis: true, # 単語内の強調を解析しない
      tables: true, # 	テーブルを解析
      space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
      hard_wrap: true, # 改行を br 要素に変換
      xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
      lax_html_blocks: true # 複数行のコードの前後に空行が不要
      # strikethrough: true, # 取り消し線(~)を解析する
    }
  end
end
```

【重要】 ここで定義した `markdown` メソッドを使うことで，マークダウン形式の文字列を HTML に変換できます

- `app/assets/stylesheets/rouge.scss.erb` を作成し，`Rouge` のシンタックスハイライト用のスタイルを追加

```erb
<%= Rouge::Themes::Github.render(scope: '.highlight') %>
```

- `app/assets/stylesheets/markdown.scss` を作成し，マークダウン専用のスタイルを追加

```scss
@import "bootstrap/scss/bootstrap";

.markdown {
  table {
    @extend .table;
    display: block;
    overflow-x: scroll;
    white-space: nowrap;
    -webkit-overflow-scrolling: touch;
    border: initial;

    thead {
      background-color: #EEFFFF;
    }
  }

  h1 {
    font-size: 1.75rem;
    text-align: left;
  }

  pre {
    overflow: auto;
    word-wrap: normal;
    white-space: pre;
    background-color: #f6ffff;
    padding: 0.5rem;
    margin: 1rem 0;
    border: 2px dashed #d6dddd;

    code {
      table.rouge-table {
        margin: 0;

        td.rouge-code {
          padding: 0;
          vertical-align: top;

          pre {
            padding: 5px 10px;
          }
        }
      }
    }
  }
}
```

【重要】 `markdown` クラスを付けたタグで囲むことで，マークダウン用のスタイルが適用されます。例として，次をビューファイルに追加して動作確認をしてみましょう。

```erb
<% 
  str = <<~TEXT
  | HTTPメソッド | URL             | アクション   | 役割             |
  |----------|-----------------|---------|----------------|
  | GET      | /users          | index   | 一覧表示         |
  | GET      | /users/new      | new     | 新規投稿フォーム表示 |
  | POST     | /users          | create  | 新規投稿処理     |
  | GET      | /users/:id      | show    | 詳細表示         |
  | GET      | /users/:id/edit | edit    | 更新フォーム表示     |
  | PATCH    | /users/:id      | update  | 更新処理         |
  | DELETE   | /users/:id      | destroy | 削除処理         |
TEXT
%>
<div class="markdown">
  <%= markdown(str) %>
</div>
```

- 以上を利用して，詳細ページを実装
  - 「タイトル(title)」と「内容(content)」を表示
  - 「内容」はマークダウンを変換した表示ができるようにすること
  - 詳細ページには「読破済み」機能は実装しないこととする

## 参考文献

- [【公式】Redcarpet](https://github.com/vmg/redcarpet)
- [【公式】Rouge](https://github.com/rouge-ruby/rouge)

## 動作確認

- 一覧ページのカードから対応する詳細ページに遷移できる
- 詳細ページで，下図のようにマークダウンを反映したスタイルとなっている

![text-show](public/readme_images/text-show.png)

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行